### PR TITLE
Quality of life change for developers who shade this library into their plugins

### DIFF
--- a/src/main/java/fr/minuskube/inv/SmartInvsPlugin.java
+++ b/src/main/java/fr/minuskube/inv/SmartInvsPlugin.java
@@ -4,24 +4,30 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public class SmartInvsPlugin extends JavaPlugin {
 
-    private static SmartInvsPlugin instance;
+    private static JavaPlugin instance;
     private static InventoryManager invManager;
 
     @Override
     public void onEnable() {
-        instance = this;
-
-        invManager = new InventoryManager(this);
-        invManager.init();
+        setPlugin(this);
     }
 
     @Override
     public void onDisable() {
-        instance = null;
-        invManager = null;
+        deleteStaticReferences();
     }
 
     public static InventoryManager manager() { return invManager; }
-    public static SmartInvsPlugin instance() { return instance; }
+    public static JavaPlugin instance() { return instance; }
 
+    public static void setPlugin(JavaPlugin javaPlugin) {
+        instance = javaPlugin;
+        invManager = new InventoryManager(javaPlugin);
+        invManager.init();
+    }
+
+    public static void deleteStaticReferences() {
+        instance = null;
+        invManager = null;
+    }
 }


### PR DESCRIPTION
With these simple changes in the commit developers who shade SmartInvs into their final plugin jar no longer need to do this:
```java
SmartInventory.builder()[...].manager(CUSTOMMANAGER).build();
```
But can just do this:

Main class:
```java
@Override
public void onEnable() {
	SmartInvsPlugin.setPlugin(this);
}

@Override
public void onDisable() {
	SmartInvsPlugin.deleteStaticReferences();
}
```
And use it like its a provided plugin
```java
SmartInventory.builder()[...].build();
```