### PR TITLE
Fixed clickable items not working for on click

### DIFF
--- a/src/main/java/fr/minuskube/inv/InventoryManager.java
+++ b/src/main/java/fr/minuskube/inv/InventoryManager.java
@@ -1,6 +1,7 @@
 package fr.minuskube.inv;
 
 import fr.minuskube.inv.content.InventoryContents;
+import fr.minuskube.inv.content.SlotPos;
 import fr.minuskube.inv.opener.ChestInventoryOpener;
 import fr.minuskube.inv.opener.InventoryOpener;
 import fr.minuskube.inv.opener.SpecialInventoryOpener;
@@ -137,7 +138,7 @@ public class InventoryManager {
                         .filter(listener -> listener.getType() == InventoryClickEvent.class)
                         .forEach(listener -> ((InventoryListener<InventoryClickEvent>) listener).accept(e));
 
-                //contents.get(p).get(row, column).ifPresent(item -> item.run(e));
+                contents.get(p).get(row, column).ifPresent(item -> item.run(new ItemClickData(e, p, e.getCurrentItem(), SlotPos.of(row, column))));
 
                 p.updateInventory();
             }


### PR DESCRIPTION
So, I am making a plugin with version 1.3.0 of SmartInvs, and noticed that not even a single ClickableItem's on click listener worked. 

Turns out, this line commented out, because the code was deprecated, but it was forgotten to add the new way of handling this, so I have fixed it, by creating an ItemClickData object with the parameters that make sense for me