### PR TITLE
Implemented improvements to the ClickableItem suggested in issue #39

### DIFF
--- a/src/main/java/fr/minuskube/inv/ClickableItem.java
+++ b/src/main/java/fr/minuskube/inv/ClickableItem.java
@@ -1,9 +1,11 @@
 package fr.minuskube.inv;
 
+import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 @SuppressWarnings({ "unchecked", "deprecation" })
 public class ClickableItem {
@@ -13,9 +15,13 @@ public class ClickableItem {
      */
     public static final ClickableItem NONE = empty(null);
 
+    private static final Predicate<Player> ALWAYS_TRUE = p -> true;
+
     private final ItemStack item;
     private final Consumer<?> consumer;
     private final boolean legacy;
+    private Predicate<Player> canSee, canClick;
+    private ItemStack notVisibleFallBackItem;
 
     private ClickableItem(ItemStack item, Consumer<?> consumer, boolean legacy) {
         this.item = item;
@@ -67,11 +73,13 @@ public class ClickableItem {
     @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     public void run(InventoryClickEvent e) {
-        if(!this.legacy)
-            return;
+        if (canSee.test((Player) e.getWhoClicked()) && canClick.test((Player) e.getWhoClicked())) {
+            if(!this.legacy)
+                return;
 
-        Consumer<InventoryClickEvent> legacyConsumer = (Consumer<InventoryClickEvent>) this.consumer;
-        legacyConsumer.accept(e);
+            Consumer<InventoryClickEvent> legacyConsumer = (Consumer<InventoryClickEvent>) this.consumer;
+            legacyConsumer.accept(e);
+        }
     }
 
     /**
@@ -90,25 +98,105 @@ public class ClickableItem {
      * @param data the data of the click
      */
     public void run(ItemClickData data) {
-        if(this.legacy) {
-            if(data.getEvent() instanceof InventoryClickEvent) {
-                InventoryClickEvent event = (InventoryClickEvent) data.getEvent();
+        if (canSee.test(data.getPlayer()) && canClick.test(data.getPlayer())) {
+            if(this.legacy) {
+                if(data.getEvent() instanceof InventoryClickEvent) {
+                    InventoryClickEvent event = (InventoryClickEvent) data.getEvent();
 
-                this.run(event);
+                    this.run(event);
+                }
+            } else {
+                Consumer<ItemClickData> newConsumer = (Consumer<ItemClickData>) this.consumer;
+                newConsumer.accept(data);
             }
-        } else {
-            Consumer<ItemClickData> newConsumer = (Consumer<ItemClickData>) this.consumer;
-            newConsumer.accept(data);
         }
     }
 
     /**
-     * Returns the item contained in this ClickableItem.
+     * Returns the item contained in this ClickableItem disregarding the visibility test set via {@link #canSee(Predicate, ItemStack)}.
      * <br>
      * <b>Warning:</b> The item can be <code>null</code>.
      *
      * @return the item, or <code>null</code> if there is no item
      */
-    public ItemStack getItem() { return this.item; }
+    public ItemStack getItem() {
+        return this.item;
+    }
 
+    /**
+     * Returns the item contained in this ClickableItem or the fallback item, if the player is not allowed to see the item.
+     * <br>
+     * <b>Warning:</b> The item can be <code>null</code>.
+     *
+     * @param player The player to test against if he can see this item
+     * @return the item, the fallback item when not visible to the player, or <code>null</code> if there is no item
+     */
+    public ItemStack getItem(Player player) {
+        if (canSee.test(player)) {
+            return this.item;
+        } else {
+            return this.notVisibleFallBackItem;
+        }
+    }
+
+    /**
+     * Sets a test to check if a player is allowed to see this item.
+     * <br>
+     * Note: If the player is not allowed to see the item, in the inventory this item will be empty.
+     * <br>
+     * Examples:
+     * <ul>
+     *     <li><code>.canSee(player -> player.hasPermission("my.permission"))</code></li>
+     *     <li><code>.canSee(player -> player.getHealth() >= 10)</code></li>
+     * </ul>
+     *
+     * @param canSee the test, if a player should be allowed to see this item
+     *
+     * @return <code>this</code> for a builder-like usage
+     *
+     * @see #canSee(Predicate, ItemStack) If you want to set a specific fallback item
+     */
+    public ClickableItem canSee(Predicate<Player> canSee) {
+        return canSee(canSee, null);
+    }
+
+    /**
+     * Sets a test to check if a player is allowed to see this item.
+     * <br>
+     * If the player is <b>not</b> allowed to see the item, the fallback item will be used instead.
+     * <br>
+     * Note: If the player is not allowed to see the item, the on click handler will not be run
+     * <br>
+     * Examples:
+     * <ul>
+     *     <li><code>.canSee(player -> player.hasPermission("my.permission"), backgroundItem)</code></li>
+     *     <li><code>.canSee(player -> player.getHealth() >= 10, backgroundItem)</code></li>
+     * </ul>
+     *
+     * @param canSee       the test, if a player should be allowed to see this item
+     * @param fallBackItem the item that should be used, if the player is <b>not</b> allowed to see the item
+     *
+     * @return <code>this</code> for a builder-like usage
+     *
+     * @see #canSee(Predicate) If you want the slot to be empty
+     */
+    public ClickableItem canSee(Predicate<Player> canSee, ItemStack fallBackItem) {
+        this.canSee = canSee;
+        this.notVisibleFallBackItem = fallBackItem;
+        return this;
+    }
+
+    /**
+     * Sets a test to check if a player is allowed to click the item.
+     * <br>
+     * If a player is not allowed to click this item, the on click handler provided at creation will not be run
+     *
+     * @param canClick the test, if a player should be allowed to see this item
+     *
+     * @return <code>this</code> for a builder-like usage
+     */
+    public ClickableItem canClick(Predicate<Player> canClick) {
+        this.canClick = canClick;
+        return this;
+    }
 }

--- a/src/main/java/fr/minuskube/inv/content/InventoryContents.java
+++ b/src/main/java/fr/minuskube/inv/content/InventoryContents.java
@@ -596,7 +596,7 @@ public interface InventoryContents {
                 return this;
 
             contents[row][column] = item;
-            update(row, column, item != null ? item.getItem() : null);
+            update(row, column, item == null ? null : item.getItem(player));
             return this;
         }
 


### PR DESCRIPTION
Implemented the canSee and canClick like suggested in the pull request and also added the fallback item for people who use a background like glass panes, so you don't have an empty slot in your inventory.