### PR TITLE
Implement #75: Inventory Update Frequency can now be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # SmartInvs
 Advanced Inventory API for your Minecraft Bukkit plugins.
 
-*Tested Minecraft versions: 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13*  
+*Tested Minecraft versions: 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14*  
 **You can use this as a Plugin, or use it as a library** (see [the docs](https://minuskube.gitbooks.io/smartinvs/))
 
 ## Features

--- a/src/main/java/fr/minuskube/inv/InventoryManager.java
+++ b/src/main/java/fr/minuskube/inv/InventoryManager.java
@@ -210,6 +210,7 @@ public class InventoryManager {
 
             if(inv.isCloseable()) {
                 e.getInventory().clear();
+                InventoryManager.this.cancelUpdateTask(p);
 
                 inventories.remove(p);
                 contents.remove(p);

--- a/src/main/java/fr/minuskube/inv/InventoryManager.java
+++ b/src/main/java/fr/minuskube/inv/InventoryManager.java
@@ -50,7 +50,7 @@ public class InventoryManager {
     public void init() {
         pluginManager.registerEvents(new InvListener(), plugin);
 
-        new InvTask().runTaskTimer(plugin, 1, 1);
+//        new InvTask().runTaskTimer(plugin, 1, 1);
     }
 
     public Optional<InventoryOpener> findOpener(InventoryType type) {

--- a/src/main/java/fr/minuskube/inv/InventoryManager.java
+++ b/src/main/java/fr/minuskube/inv/InventoryManager.java
@@ -112,8 +112,9 @@ public class InventoryManager {
     
     protected void cancelUpdateTask(Player p) {
     	if(updateTasks.containsKey(p)) {
-    		int bukkitTaskId = updateTasks.get(p).getTaskId();
+    		int bukkitTaskId = this.updateTasks.get(p).getTaskId();
     		Bukkit.getScheduler().cancelTask(bukkitTaskId);
+    		this.updateTasks.remove(p);
     	}
     }
 

--- a/src/main/java/fr/minuskube/inv/SmartInventory.java
+++ b/src/main/java/fr/minuskube/inv/SmartInventory.java
@@ -4,7 +4,6 @@ import fr.minuskube.inv.content.InventoryContents;
 import fr.minuskube.inv.content.InventoryProvider;
 import fr.minuskube.inv.opener.InventoryOpener;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.inventory.InventoryCloseEvent;
@@ -150,7 +149,7 @@ public class SmartInventory {
          * @throws IllegalArgumentException If frequency is smaller than 1.
          */
         public Builder updateFrequency(int frequency) {
-        	Preconditions.checkArgument(frequency > 1, "frequency must be > 0");
+        	Preconditions.checkArgument(frequency > 0, "frequency must be > 0");
         	this.updateFrequency = frequency;
         	return this;
         }

--- a/src/main/java/fr/minuskube/inv/SmartInventory.java
+++ b/src/main/java/fr/minuskube/inv/SmartInventory.java
@@ -3,6 +3,8 @@ package fr.minuskube.inv;
 import fr.minuskube.inv.content.InventoryContents;
 import fr.minuskube.inv.content.InventoryProvider;
 import fr.minuskube.inv.opener.InventoryOpener;
+
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.inventory.InventoryCloseEvent;
@@ -58,7 +60,7 @@ public class SmartInventory {
 
         this.manager.setInventory(player, this);
         this.manager.scheduleUpdateTask(player, this);
-
+        
         return handle;
     }
 

--- a/src/main/java/fr/minuskube/inv/SmartInventory.java
+++ b/src/main/java/fr/minuskube/inv/SmartInventory.java
@@ -57,6 +57,7 @@ public class SmartInventory {
         Inventory handle = opener.open(this, player);
 
         this.manager.setInventory(player, this);
+        this.manager.scheduleUpdateTask(player, this);
 
         return handle;
     }
@@ -72,6 +73,7 @@ public class SmartInventory {
         player.closeInventory();
 
         this.manager.setContents(player, null);
+        this.manager.cancelUpdateTask(player);
     }
 
     public String getId() { return id; }

--- a/src/main/java/fr/minuskube/inv/SmartInventory.java
+++ b/src/main/java/fr/minuskube/inv/SmartInventory.java
@@ -21,6 +21,7 @@ public class SmartInventory {
     private InventoryType type;
     private int rows, columns;
     private boolean closeable;
+    private int updateFrequency;
 
     private InventoryProvider provider;
     private SmartInventory parent;

--- a/src/main/java/fr/minuskube/inv/SmartInventory.java
+++ b/src/main/java/fr/minuskube/inv/SmartInventory.java
@@ -82,6 +82,8 @@ public class SmartInventory {
 
     public boolean isCloseable() { return closeable; }
     public void setCloseable(boolean closeable) { this.closeable = closeable; }
+    
+    public int getUpdateFrequency() { return updateFrequency; }
 
     public InventoryProvider getProvider() { return provider; }
     public Optional<SmartInventory> getParent() { return Optional.ofNullable(parent); }
@@ -99,6 +101,7 @@ public class SmartInventory {
         private InventoryType type = InventoryType.CHEST;
         private int rows = 6, columns = 9;
         private boolean closeable = true;
+        private int updateFrequency = 1;
 
         private InventoryManager manager;
         private InventoryProvider provider;
@@ -132,6 +135,16 @@ public class SmartInventory {
         public Builder closeable(boolean closeable) {
             this.closeable = closeable;
             return this;
+        }
+        
+        /**
+         * This method is used to configure the frequency at which the {@link InventoryProvider#update(Player, InventoryContents)}
+         * method is called. Defaults to 1
+         * @param frequency The inventory update frequency, in ticks
+         */
+        public Builder updateFrequency(int frequency) {
+        	this.updateFrequency = frequency;
+        	return this;
         }
 
         public Builder provider(InventoryProvider provider) {
@@ -171,6 +184,7 @@ public class SmartInventory {
             inv.rows = this.rows;
             inv.columns = this.columns;
             inv.closeable = this.closeable;
+            inv.updateFrequency = this.updateFrequency;
             inv.provider = this.provider;
             inv.parent = this.parent;
             inv.listeners = this.listeners;

--- a/src/main/java/fr/minuskube/inv/SmartInventory.java
+++ b/src/main/java/fr/minuskube/inv/SmartInventory.java
@@ -11,6 +11,8 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 
+import com.google.common.base.Preconditions;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -145,8 +147,10 @@ public class SmartInventory {
          * This method is used to configure the frequency at which the {@link InventoryProvider#update(Player, InventoryContents)}
          * method is called. Defaults to 1
          * @param frequency The inventory update frequency, in ticks
+         * @throws IllegalArgumentException If frequency is smaller than 1.
          */
         public Builder updateFrequency(int frequency) {
+        	Preconditions.checkArgument(frequency > 1, "frequency must be > 0");
         	this.updateFrequency = frequency;
         	return this;
         }


### PR DESCRIPTION
Added a `updateFrequency` method to the SmartInventory Builder. Each time a new SmartInventory is opened, a `BukkitRunnable` is created. As soon as the inventory is closed, the task is cancelled again.