### PR TITLE
Fix #68: Make inventory default's size dependent on selected type

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # SmartInvs
 Advanced Inventory API for your Minecraft Bukkit plugins.
 
-*Tested Minecraft versions: 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13*  
+*Tested Minecraft versions: 1.7, 1.8, 1.9, 1.10, 1.11, 1.12, 1.13, 1.14*  
 **You can use this as a Plugin, or use it as a library** (see [the docs](https://minuskube.gitbooks.io/smartinvs/))
 
 ## Features

--- a/src/main/java/fr/minuskube/inv/SmartInventory.java
+++ b/src/main/java/fr/minuskube/inv/SmartInventory.java
@@ -169,8 +169,8 @@ public class SmartInventory {
             inv.id = this.id;
             inv.title = this.title;
             inv.type = this.type;
-            inv.rows = this.rows.orElse(getDefaultDimensions(type).getRow());
-            inv.columns = this.columns.orElse(getDefaultDimensions(type).getColumn());
+            inv.rows = this.rows.orElseGet(() -> getDefaultDimensions(type).getRow());
+            inv.columns = this.columns.orElseGet(() -> getDefaultDimensions(type).getColumn());
             inv.closeable = this.closeable;
             inv.provider = this.provider;
             inv.parent = this.parent;

--- a/src/main/java/fr/minuskube/inv/SmartInventory.java
+++ b/src/main/java/fr/minuskube/inv/SmartInventory.java
@@ -181,6 +181,7 @@ public class SmartInventory {
         private SlotPos getDefaultDimensions(InventoryType type) {
         	switch(type) {
         		case CHEST:
+        		case ENDER_CHEST:
         			return SlotPos.of(3, 9);
         		case HOPPER:
         			return SlotPos.of(1, 5);
@@ -189,7 +190,7 @@ public class SmartInventory {
         		case ANVIL:
         			return SlotPos.of(1, 3);
         		case BREWING:
-        			return SlotPos.of(2, 4); // ??? What should the defaults be?
+        			return SlotPos.of(1, 5);
         		case ENCHANTING:
         			return SlotPos.of(1, 2);
         		case DROPPER:
@@ -197,7 +198,7 @@ public class SmartInventory {
         		case WORKBENCH:				// WORKBENCH ... 3x3? It has the output item also though
         			return SlotPos.of(3, 3);
         		case FURNACE:
-        			return SlotPos.of(3, 2); // ?
+        			return SlotPos.of(1, 3);
         		default:
         			throw new IllegalArgumentException("Failed to get default size of unknown inventory type: " + type);
         	}

--- a/src/main/java/fr/minuskube/inv/SmartInventory.java
+++ b/src/main/java/fr/minuskube/inv/SmartInventory.java
@@ -2,6 +2,7 @@ package fr.minuskube.inv;
 
 import fr.minuskube.inv.content.InventoryContents;
 import fr.minuskube.inv.content.InventoryProvider;
+import fr.minuskube.inv.content.SlotPos;
 import fr.minuskube.inv.opener.InventoryOpener;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -96,7 +97,8 @@ public class SmartInventory {
         private String id = "unknown";
         private String title = "";
         private InventoryType type = InventoryType.CHEST;
-        private int rows = 6, columns = 9;
+        private Optional<Integer> rows = Optional.empty();
+        private Optional<Integer> columns = Optional.empty();
         private boolean closeable = true;
 
         private InventoryManager manager;
@@ -123,8 +125,8 @@ public class SmartInventory {
         }
 
         public Builder size(int rows, int columns) {
-            this.rows = rows;
-            this.columns = columns;
+            this.rows = Optional.of(rows);
+            this.columns = Optional.of(columns);
             return this;
         }
 
@@ -167,14 +169,38 @@ public class SmartInventory {
             inv.id = this.id;
             inv.title = this.title;
             inv.type = this.type;
-            inv.rows = this.rows;
-            inv.columns = this.columns;
+            inv.rows = this.rows.orElse(getDefaultDimensions(type).getRow());
+            inv.columns = this.columns.orElse(getDefaultDimensions(type).getColumn());
             inv.closeable = this.closeable;
             inv.provider = this.provider;
             inv.parent = this.parent;
             inv.listeners = this.listeners;
-
             return inv;
+        }
+
+        private SlotPos getDefaultDimensions(InventoryType type) {
+        	switch(type) {
+        		case CHEST:
+        			return SlotPos.of(3, 9);
+        		case HOPPER:
+        			return SlotPos.of(1, 5);
+        		case BEACON:
+        			return SlotPos.of(1, 1);
+        		case ANVIL:
+        			return SlotPos.of(1, 3);
+        		case BREWING:
+        			return SlotPos.of(2, 4); // ??? What should the defaults be?
+        		case ENCHANTING:
+        			return SlotPos.of(1, 2);
+        		case DROPPER:
+        		case DISPENSER:
+        		case WORKBENCH:				// WORKBENCH ... 3x3? It has the output item also though
+        			return SlotPos.of(3, 3);
+        		case FURNACE:
+        			return SlotPos.of(3, 2); // ?
+        		default:
+        			throw new IllegalArgumentException("Failed to get default size of unknown inventory type: " + type);
+        	}
         }
     }
 


### PR DESCRIPTION
Default inventory sizes are configurable in the `SmartInventory#getDefaultDimensions()` method. I used the `SlotPos` class to store the default row and column size, might be better to replace it with own class (or maybe just an array of 2 integers).