### PR TITLE
Prevent infinite loop crash

### DIFF
--- a/src/main/java/fr/minuskube/inv/InventoryManager.java
+++ b/src/main/java/fr/minuskube/inv/InventoryManager.java
@@ -192,6 +192,9 @@ public class InventoryManager {
 
             SmartInventory inv = inventories.get(p);
 
+            if(inv.getType() != e.getInventory().getType() || !inv.getTitle().equals(e.getView().getTitle()))
+            	return;
+
             inv.getListeners().stream()
                     .filter(listener -> listener.getType() == InventoryOpenEvent.class)
                     .forEach(listener -> ((InventoryListener<InventoryOpenEvent>) listener).accept(e));
@@ -205,6 +208,9 @@ public class InventoryManager {
                 return;
 
             SmartInventory inv = inventories.get(p);
+
+            if(inv.getType() != e.getInventory().getType() || !inv.getTitle().equals(e.getView().getTitle()))
+            	return;
 
             inv.getListeners().stream()
                     .filter(listener -> listener.getType() == InventoryCloseEvent.class)


### PR DESCRIPTION
If a plugin opens an inventory to a player while they are viewing a smartinv that is non-closeable smartinv will reopen its inventory. This causes the other plugin's inventory to close which causes another close inventory event in smartinv to reopen its inventory. When it reopens another close inventory event will occur even though the smartinv inventory is already opened for the player.

This verifies the inventory title and types match the smartinv inventory marked open to the player before performing any smartinv actions.

Here's what a thread dump would look like when this happens:
https://gist.github.com/electro2560/61069d12c7c8d670b9402d7bb2b803be