### PR TITLE
Fix #79: Click Listeners not invoked when Slot is empty

### DIFF
--- a/src/main/java/fr/minuskube/inv/InventoryManager.java
+++ b/src/main/java/fr/minuskube/inv/InventoryManager.java
@@ -128,11 +128,8 @@ public class InventoryManager {
 
             if(!inventories.containsKey(p))
                 return;
-
-            if( e.getAction() == InventoryAction.COLLECT_TO_CURSOR ||
-                e.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY ||
-                e.getAction() == InventoryAction.NOTHING) {
-
+            
+            if(e.getAction() == InventoryAction.COLLECT_TO_CURSOR || e.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY) {
                 e.setCancelled(true);
                 return;
             }

--- a/src/main/java/fr/minuskube/inv/SmartInventory.java
+++ b/src/main/java/fr/minuskube/inv/SmartInventory.java
@@ -1,21 +1,20 @@
 package fr.minuskube.inv;
 
-import fr.minuskube.inv.content.InventoryContents;
-import fr.minuskube.inv.content.InventoryProvider;
-import fr.minuskube.inv.content.SlotPos;
-import fr.minuskube.inv.opener.InventoryOpener;
-
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
-
 import com.google.common.base.Preconditions;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import fr.minuskube.inv.content.InventoryContents;
+import fr.minuskube.inv.content.InventoryProvider;
+import fr.minuskube.inv.content.SlotPos;
+import fr.minuskube.inv.opener.InventoryOpener;
 
 @SuppressWarnings("unchecked")
 public class SmartInventory {


### PR DESCRIPTION
I removed the check for `InventoryAction.NOTHING` in the `InventoryManager` and it seems to have the desired effect. Even with the check gone, I am not able to insert or remove any items from the inventory. All the other listener types also still work. So maybe that check could be removed?

It should be noted that I only tested this in MC 1.14.
