### PR TITLE
Implement #12 (Make ClickableItem work outside of SmartInventories)

### DIFF
--- a/src/main/java/fr/minuskube/inv/InventoryManager.java
+++ b/src/main/java/fr/minuskube/inv/InventoryManager.java
@@ -28,6 +28,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.*;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.plugin.PluginManager;
@@ -271,6 +272,10 @@ public class InventoryManager {
             contents.clear();
         }
 
+        @EventHandler(priority = EventPriority.LOW)
+        public void onPlayerInteract(PlayerInteractEvent e) {
+            Player p = e.getPlayer(); // TODO continue here
+        }
     }
 
     class InvTask extends BukkitRunnable {


### PR DESCRIPTION
Before I can properly start working on this, I have some questions @MinusKube.

To clarify, the following scenarios are counted as a click outside of the GUI:
 - Clicking with the item in hand / hotbar
 - The player opened his own inventory and clicks on the item by himself
But not in these cases:
 - The item is in a chest
 - The item is in a oven / workbench / other placeable block with an inventory
 - Inside a horse inventory

Also if a player clicks the item in his own inventory the event shouldn't be cancelled, correct?