### PR TITLE
Allow init of the inventory manager from outside

### DIFF
--- a/src/main/java/fr/minuskube/inv/SmartInvsPlugin.java
+++ b/src/main/java/fr/minuskube/inv/SmartInvsPlugin.java
@@ -10,8 +10,11 @@ public class SmartInvsPlugin extends JavaPlugin {
     @Override
     public void onEnable() {
         instance = this;
+        initInventoryManager(this);
+    }
 
-        invManager = new InventoryManager(this);
+    public static void initInventoryManager(JavaPlugin plugin) {
+        invManager = new InventoryManager(plugin);
         invManager.init();
     }
 


### PR DESCRIPTION
The aim of this enhancement is to allow the init of the InventoryManager instance of the program from a loaded plugin when he is shade in it (and therefore the SmartInvsPlugin class isn't loaded by the Bukkit plugin loader in this case which prevent init like actually is doing in onEnable() method).