### PR TITLE
Add methods applyRect()

### DIFF
--- a/src/test/java/fr/minuskube/inv/content/InventoryContentsTest.java
+++ b/src/test/java/fr/minuskube/inv/content/InventoryContentsTest.java
@@ -8,13 +8,13 @@ import org.bukkit.inventory.ItemStack;
 import org.junit.Test;
 
 import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class InventoryContentsTest {
-
     private static final ItemStack TEST_ITEM = new ItemStack(Material.DIRT);
     private static final ClickableItem TEST_CLICKABLE = ClickableItem.empty(TEST_ITEM);
 
@@ -96,4 +96,41 @@ public class InventoryContentsTest {
         assertEquals(contents.firstEmpty().get(), SlotPos.of(0, 1));
     }
 
+    @Test
+    public void testApplyRectRaw() {
+        SmartInventory inv = mockInventory(6, 9);
+        InventoryContents contents = new InventoryContents.Impl(inv, null);
+
+        BiConsumer<Integer, Integer> mockConsumer = mock(BiConsumer.class);
+        contents.applyRect(3,4,5,6, mockConsumer);
+
+        verify(mockConsumer, times(1)).accept(eq(3), eq(4));
+        verify(mockConsumer, times(1)).accept(eq(3), eq(5));
+        verify(mockConsumer, times(1)).accept(eq(3), eq(6));
+
+        verify(mockConsumer, times(1)).accept(eq(4), eq(4));
+        verify(mockConsumer, times(1)).accept(eq(4), eq(5));
+        verify(mockConsumer, times(1)).accept(eq(4), eq(6));
+
+        verify(mockConsumer, times(1)).accept(eq(5), eq(4));
+        verify(mockConsumer, times(1)).accept(eq(5), eq(5));
+        verify(mockConsumer, times(1)).accept(eq(5), eq(6));
+    }
+
+    @Test
+    public void testApplyRectSlot() {
+        SmartInventory inv = mockInventory(6, 9);
+        InventoryContents contents = new InventoryContents.Impl(inv, null);
+
+        contents.set(0, 0, ClickableItem.empty(TEST_ITEM));
+        contents.set(3, 4, ClickableItem.empty(TEST_ITEM));
+        contents.set(4, 5, ClickableItem.empty(TEST_ITEM));
+        contents.set(5, 6, ClickableItem.empty(TEST_ITEM));
+        contents.set(6, 7, ClickableItem.empty(TEST_ITEM));
+
+        Consumer<ClickableItem> mockConsumer = mock(Consumer.class);
+        contents.applyRect(3,4,5,6, mockConsumer);
+
+        verify(mockConsumer, times(3)).accept(any(ClickableItem.class));
+    }
 }


### PR DESCRIPTION
This allows more flexible use of the API.

For example, to apply setEditable() option for all of the items, which are usually added by fill~() methods, we have to use the for loop.

However, such a for loop is already used in the API itself (in the fillRect()), so it causes unnecessary boilerplate codes.

Below is my use case:
`contents.applyRect(3,1,4,3, (row, col) -> contents.setEditable(SlotPos.of(row, col), true));`