### PR TITLE
add try/finally block

### DIFF
--- a/src/test/java/fr/minuskube/inv/content/InventoryContentsTest.java
+++ b/src/test/java/fr/minuskube/inv/content/InventoryContentsTest.java
@@ -8,13 +8,13 @@ import org.bukkit.inventory.ItemStack;
 import org.junit.Test;
 
 import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class InventoryContentsTest {
-
     private static final ItemStack TEST_ITEM = new ItemStack(Material.DIRT);
     private static final ClickableItem TEST_CLICKABLE = ClickableItem.empty(TEST_ITEM);
 
@@ -96,4 +96,41 @@ public class InventoryContentsTest {
         assertEquals(contents.firstEmpty().get(), SlotPos.of(0, 1));
     }
 
+    @Test
+    public void testApplyRectRaw() {
+        SmartInventory inv = mockInventory(6, 9);
+        InventoryContents contents = new InventoryContents.Impl(inv, null);
+
+        BiConsumer<Integer, Integer> mockConsumer = mock(BiConsumer.class);
+        contents.applyRect(3,4,5,6, mockConsumer);
+
+        verify(mockConsumer, times(1)).accept(eq(3), eq(4));
+        verify(mockConsumer, times(1)).accept(eq(3), eq(5));
+        verify(mockConsumer, times(1)).accept(eq(3), eq(6));
+
+        verify(mockConsumer, times(1)).accept(eq(4), eq(4));
+        verify(mockConsumer, times(1)).accept(eq(4), eq(5));
+        verify(mockConsumer, times(1)).accept(eq(4), eq(6));
+
+        verify(mockConsumer, times(1)).accept(eq(5), eq(4));
+        verify(mockConsumer, times(1)).accept(eq(5), eq(5));
+        verify(mockConsumer, times(1)).accept(eq(5), eq(6));
+    }
+
+    @Test
+    public void testApplyRectSlot() {
+        SmartInventory inv = mockInventory(6, 9);
+        InventoryContents contents = new InventoryContents.Impl(inv, null);
+
+        contents.set(0, 0, ClickableItem.empty(TEST_ITEM));
+        contents.set(3, 4, ClickableItem.empty(TEST_ITEM));
+        contents.set(4, 5, ClickableItem.empty(TEST_ITEM));
+        contents.set(5, 6, ClickableItem.empty(TEST_ITEM));
+        contents.set(6, 7, ClickableItem.empty(TEST_ITEM));
+
+        Consumer<ClickableItem> mockConsumer = mock(Consumer.class);
+        contents.applyRect(3,4,5,6, mockConsumer);
+
+        verify(mockConsumer, times(3)).accept(any(ClickableItem.class));
+    }
 }


### PR DESCRIPTION
This prevent the exception caused by the registered listener causing the plugin to spam the console.

Spam example:

```
[17:09:24] [Server thread/WARN]: [SmartInvs] Task #15804 for SmartInvs v1.3.0 generated an exception
java.lang.ArrayIndexOutOfBoundsException: 7
	at java.util.Arrays$ArrayList.set(Arrays.java:3846) ~[?:1.8.0_265]
	at net.minecraft.server.v1_16_R1.NonNullList.set(SourceFile:53) ~[patched_1.16.1.jar:git-Paper-135]
	at net.minecraft.server.v1_16_R1.InventoryCrafting.setItem(InventoryCrafting.java:134) ~[patched_1.16.1.jar:git-Paper-135]
	at org.bukkit.craftbukkit.v1_16_R1.inventory.CraftInventoryCrafting.setItem(CraftInventoryCrafting.java:80) ~[patched_1.16.1.jar:git-Paper-135]
	at fr.minuskube.inv.content.InventoryContents$Impl.update(InventoryContents.java:929) ~[?:?]
	at fr.minuskube.inv.content.InventoryContents$Impl.set(InventoryContents.java:696) ~[?:?]
	at io.github.wysohn.tradegui.manager.gui.GUIPairNode.update(GUIPairNode.java:117) ~[?:?]
	at fr.minuskube.inv.InventoryManager$PlayerInvTask.run(InventoryManager.java:299) ~[?:?]
	at org.bukkit.craftbukkit.v1_16_R1.scheduler.CraftTask.run(CraftTask.java:99) ~[patched_1.16.1.jar:git-Paper-135]
	at org.bukkit.craftbukkit.v1_16_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:468) ~[patched_1.16.1.jar:git-Paper-135]
	at net.minecraft.server.v1_16_R1.MinecraftServer.b(MinecraftServer.java:1298) ~[patched_1.16.1.jar:git-Paper-135]
	at net.minecraft.server.v1_16_R1.DedicatedServer.b(DedicatedServer.java:377) ~[patched_1.16.1.jar:git-Paper-135]
	at net.minecraft.server.v1_16_R1.MinecraftServer.a(MinecraftServer.java:1213) ~[patched_1.16.1.jar:git-Paper-135]
	at net.minecraft.server.v1_16_R1.MinecraftServer.v(MinecraftServer.java:1001) ~[patched_1.16.1.jar:git-Paper-135]
	at net.minecraft.server.v1_16_R1.MinecraftServer.lambda$a$0(MinecraftServer.java:177) ~[patched_1.16.1.jar:git-Paper-135]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_265]
```

Cause the exception from the registered listener prevented the rather codes from being executed, so updating task is keep calling the update() method of discarded instance.