### PR TITLE
Inventory tracking prototype

### DIFF
--- a/src/main/java/fr/minuskube/inv/InventoryManager.java
+++ b/src/main/java/fr/minuskube/inv/InventoryManager.java
@@ -304,7 +304,11 @@ public class InventoryManager {
 
         @Override
         public void run() {
-            new HashMap<>(inventories).forEach((player, inv) -> inv.getProvider().update(player, contents.get(player)));
+            new HashMap<>(inventories).forEach((inventory, smartInventory) -> inventory.getViewers().stream()
+                    .filter(Player.class::isInstance)
+                    .map(Player.class::cast)
+                    .findFirst()
+                    .ifPresent(player -> smartInventory.getProvider().update(player, contents.get(inventory))));
         }
 
     }
@@ -323,7 +327,11 @@ public class InventoryManager {
 
         @Override
         public void run() {
-            provider.update(this.inventorylayer, this.contents);
+            inventorylayer.getViewers().stream()
+                    .filter(Player.class::isInstance)
+                    .map(Player.class::cast)
+                    .findFirst()
+                    .ifPresent(player -> provider.update(player, this.contents));
         }
     	
     }

--- a/src/main/java/fr/minuskube/inv/InventoryManager.java
+++ b/src/main/java/fr/minuskube/inv/InventoryManager.java
@@ -241,14 +241,16 @@ public class InventoryManager {
                         .filter(listener -> listener.getType() == InventoryCloseEvent.class)
                         .forEach(listener -> ((InventoryListener<InventoryCloseEvent>) listener).accept(e));
             } finally {
-                if(inv.isCloseable()) {
+                // if closeable, just close.
+                // if not closeable, check whether it's marked as closed before closing it.
+                //     if not marked as closed, it should re-open the inventory
+                if(inv.isCloseable() || inv.isClosed()) {
                     e.getInventory().clear();
                     InventoryManager.this.cancelUpdateTask(inventory);
 
                     inventories.remove(inventory);
                     contents.remove(inventory);
-                }
-                else
+                } else
                     Bukkit.getScheduler().runTask(plugin, () -> player.openInventory(e.getInventory()));
             }
         }

--- a/src/main/java/fr/minuskube/inv/InventoryManager.java
+++ b/src/main/java/fr/minuskube/inv/InventoryManager.java
@@ -163,7 +163,7 @@ public class InventoryManager {
                 return;
             }
 
-            if(inventory == player.getOpenInventory().getTopInventory()) {
+            if(e.getClickedInventory() == player.getOpenInventory().getTopInventory()) {
                 int row = e.getSlot() / 9;
                 int column = e.getSlot() % 9;
                 

--- a/src/main/java/fr/minuskube/inv/SmartInventory.java
+++ b/src/main/java/fr/minuskube/inv/SmartInventory.java
@@ -83,7 +83,7 @@ public class SmartInventory {
             properties.forEach(contents::setProperty);
 
             this.manager.setContents(handle, contents);
-            this.provider.init(handle, contents);
+            this.provider.init(player, contents);
 
             this.manager.setInventory(handle, this);
             this.manager.scheduleUpdateTask(handle, this);
@@ -187,7 +187,7 @@ public class SmartInventory {
         }
         
         /**
-         * This method is used to configure the frequency at which the {@link InventoryProvider#update(Inventory, InventoryContents)}
+         * This method is used to configure the frequency at which the {@link InventoryProvider#update(Player, InventoryContents)}
          * method is called. Defaults to 1
          * @param frequency The inventory update frequency, in ticks
          * @throws IllegalArgumentException If frequency is smaller than 1.

--- a/src/main/java/fr/minuskube/inv/content/InventoryProvider.java
+++ b/src/main/java/fr/minuskube/inv/content/InventoryProvider.java
@@ -16,11 +16,11 @@
 
 package fr.minuskube.inv.content;
 
-import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
 
 public interface InventoryProvider {
 
-    void init(Player player, InventoryContents contents);
-    void update(Player player, InventoryContents contents);
+    void init(Inventory inventory, InventoryContents contents);
+    void update(Inventory inventory, InventoryContents contents);
 
 }

--- a/src/main/java/fr/minuskube/inv/content/InventoryProvider.java
+++ b/src/main/java/fr/minuskube/inv/content/InventoryProvider.java
@@ -16,11 +16,11 @@
 
 package fr.minuskube.inv.content;
 
-import org.bukkit.inventory.Inventory;
+import org.bukkit.entity.Player;
 
 public interface InventoryProvider {
 
-    void init(Inventory inventory, InventoryContents contents);
-    void update(Inventory inventory, InventoryContents contents);
+    void init(Player player, InventoryContents contents);
+    void update(Player player, InventoryContents contents);
 
 }

--- a/src/main/java/fr/minuskube/inv/opener/ChestInventoryOpener.java
+++ b/src/main/java/fr/minuskube/inv/opener/ChestInventoryOpener.java
@@ -36,7 +36,7 @@ public class ChestInventoryOpener implements InventoryOpener {
         InventoryManager manager = inv.getManager();
         Inventory handle = Bukkit.createInventory(player, inv.getRows() * inv.getColumns(), inv.getTitle());
 
-        fill(handle, manager.getContents(player).get(), player);
+        fill(handle, manager.getContents(handle).get(), player);
 
         player.openInventory(handle);
         return handle;

--- a/src/main/java/fr/minuskube/inv/opener/ChestInventoryOpener.java
+++ b/src/main/java/fr/minuskube/inv/opener/ChestInventoryOpener.java
@@ -24,10 +24,12 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 
+import java.util.function.Consumer;
+
 public class ChestInventoryOpener implements InventoryOpener {
 
     @Override
-    public Inventory open(SmartInventory inv, Player player) {
+    public Inventory open(SmartInventory inv, Player player, Consumer<Inventory> doBeforeOpen) {
         Preconditions.checkArgument(inv.getColumns() == 9,
                 "The column count for the chest inventory must be 9, found: %s.", inv.getColumns());
         Preconditions.checkArgument(inv.getRows() >= 1 && inv.getRows() <= 6,
@@ -35,6 +37,7 @@ public class ChestInventoryOpener implements InventoryOpener {
 
         InventoryManager manager = inv.getManager();
         Inventory handle = Bukkit.createInventory(player, inv.getRows() * inv.getColumns(), inv.getTitle());
+        doBeforeOpen.accept(handle);
 
         fill(handle, manager.getContents(handle).get(), player);
 

--- a/src/main/java/fr/minuskube/inv/opener/InventoryOpener.java
+++ b/src/main/java/fr/minuskube/inv/opener/InventoryOpener.java
@@ -24,9 +24,23 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 
+import java.util.function.Consumer;
+
 public interface InventoryOpener {
 
-    Inventory open(SmartInventory inv, Player player);
+    /**
+     * Create Inventory, fill the contents, and open the Inventory for Player.
+     * For 'fill' step, it expects the contents of the Inventory is already registered
+     * with {@link fr.minuskube.inv.InventoryManager#setContents(Inventory, InventoryContents)}.
+     * To do so, use doBeforeOpen argument.
+     * @param inv SmartInventory
+     * @param player target Player
+     * @param doBeforeOpen logic to be executed in between Inventory instantiation
+     *                     and {@link Player#openInventory(Inventory)}, Great place
+     *                     to register SmartInventory to {@link fr.minuskube.inv.InventoryManager};
+     * @return
+     */
+    Inventory open(SmartInventory inv, Player player, Consumer<Inventory> doBeforeOpen);
     boolean supports(InventoryType type);
 
     default void fill(Inventory handle, InventoryContents contents, Player player) {

--- a/src/main/java/fr/minuskube/inv/opener/SpecialInventoryOpener.java
+++ b/src/main/java/fr/minuskube/inv/opener/SpecialInventoryOpener.java
@@ -25,6 +25,7 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 public class SpecialInventoryOpener implements InventoryOpener {
 
@@ -41,9 +42,10 @@ public class SpecialInventoryOpener implements InventoryOpener {
     );
 
     @Override
-    public Inventory open(SmartInventory inv, Player player) {
+    public Inventory open(SmartInventory inv, Player player, Consumer<Inventory> doBeforeOpen) {
         InventoryManager manager = inv.getManager();
         Inventory handle = Bukkit.createInventory(player, inv.getType(), inv.getTitle());
+        doBeforeOpen.accept(handle);
 
         fill(handle, manager.getContents(handle).get(), player);
 

--- a/src/main/java/fr/minuskube/inv/opener/SpecialInventoryOpener.java
+++ b/src/main/java/fr/minuskube/inv/opener/SpecialInventoryOpener.java
@@ -45,7 +45,7 @@ public class SpecialInventoryOpener implements InventoryOpener {
         InventoryManager manager = inv.getManager();
         Inventory handle = Bukkit.createInventory(player, inv.getType(), inv.getTitle());
 
-        fill(handle, manager.getContents(player).get(), player);
+        fill(handle, manager.getContents(handle).get(), player);
 
         player.openInventory(handle);
         return handle;

--- a/src/test/java/fr/minuskube/inv/content/InventoryContentsTest.java
+++ b/src/test/java/fr/minuskube/inv/content/InventoryContentsTest.java
@@ -8,13 +8,13 @@ import org.bukkit.inventory.ItemStack;
 import org.junit.Test;
 
 import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class InventoryContentsTest {
-
     private static final ItemStack TEST_ITEM = new ItemStack(Material.DIRT);
     private static final ClickableItem TEST_CLICKABLE = ClickableItem.empty(TEST_ITEM);
 
@@ -96,4 +96,41 @@ public class InventoryContentsTest {
         assertEquals(contents.firstEmpty().get(), SlotPos.of(0, 1));
     }
 
+    @Test
+    public void testApplyRectRaw() {
+        SmartInventory inv = mockInventory(6, 9);
+        InventoryContents contents = new InventoryContents.Impl(inv, null);
+
+        BiConsumer<Integer, Integer> mockConsumer = mock(BiConsumer.class);
+        contents.applyRect(3,4,5,6, mockConsumer);
+
+        verify(mockConsumer, times(1)).accept(eq(3), eq(4));
+        verify(mockConsumer, times(1)).accept(eq(3), eq(5));
+        verify(mockConsumer, times(1)).accept(eq(3), eq(6));
+
+        verify(mockConsumer, times(1)).accept(eq(4), eq(4));
+        verify(mockConsumer, times(1)).accept(eq(4), eq(5));
+        verify(mockConsumer, times(1)).accept(eq(4), eq(6));
+
+        verify(mockConsumer, times(1)).accept(eq(5), eq(4));
+        verify(mockConsumer, times(1)).accept(eq(5), eq(5));
+        verify(mockConsumer, times(1)).accept(eq(5), eq(6));
+    }
+
+    @Test
+    public void testApplyRectSlot() {
+        SmartInventory inv = mockInventory(6, 9);
+        InventoryContents contents = new InventoryContents.Impl(inv, null);
+
+        contents.set(0, 0, ClickableItem.empty(TEST_ITEM));
+        contents.set(3, 4, ClickableItem.empty(TEST_ITEM));
+        contents.set(4, 5, ClickableItem.empty(TEST_ITEM));
+        contents.set(5, 6, ClickableItem.empty(TEST_ITEM));
+        contents.set(6, 7, ClickableItem.empty(TEST_ITEM));
+
+        Consumer<ClickableItem> mockConsumer = mock(Consumer.class);
+        contents.applyRect(3,4,5,6, mockConsumer);
+
+        verify(mockConsumer, times(3)).accept(any(ClickableItem.class));
+    }
 }


### PR DESCRIPTION
As proposed in #157, I've done some refactoring to implement the idea.

Already tested with my own plugin, but more test would be ideal.

---

### So why this work? 
Lets go back to the Java basics.

We know that we can't compare two String just by using == operator.

But why is that so? because == checks if two instances are exactly the same, not if they are 'equal.' That's why we need to compare two Strings like `"abc".equals("abc")` as when we use the quote to create String literal, it instantiate new String even though the value is the same. So "abc" and "abc" are 'equal' yet not the same instance.

Well, then why is that even relevant for the PR?

Because when Bukkit#createInventory() method is called, Bukkit API instantiate Inventory for us. And throughout all the complicated Event handlings, this specific Inventory  'instance' does not change.

For example, if we listen to InventoryClickEvent, InventoryOpenEvent, and InventoryCloseEvent, the Inventory instance returned by getInventory() would be the exact same Inventory instance we've created by Bukkit#createInventory().

In current implementation, we map SmartInventory with Player instance, yet in this PR, we will map SmartInvetory to Inventory instance directly.

### But mapping to Player instance works; why change?

#### 1. It's more straight forward.

Mapping to Player works, definitely. We can think it as we are keeping tracking of `which SmartInventory a Player is currently dealing with`

However, things gets really ugly when handling transition between two GUIs. While mapping Player to SmartInventory, it's done by un-registering the previous SmartInventory (which is named oldInv) and then registering the new Inventory to open. 

But as we already know, SmartInventory is per Player instance, so at this point, listening to InventoryOpenEvent or InventoryCloseEvent is very complicated process. Before un-registering the previous SmartInventory, it manually fires InventoryCloseEvent, and if the listener of InventoryCloseEvent is opening another SmartInventory, it will close the Inventory that the Player is currently dealing with, so it fires InventoryCloseEvent, and so on and so on.

I'm still getting confused what's going on while writing this PR. The point is, it doesn't have to be this complicate!

Now, using implementation in this PR, each Inventory maps one SmartInventory, which is responsible for the Inventory, so InventoryCloseEvent, InventoryOpenEvent, or whatsoever Inventory event is no longer bounded to any other Inventory. Even opening another SmartInventory inside the InventoryCloseEvent is safe, since the new Inventory instance is not the same instance as the Inventory instance the Player is currently dealing with.

#### 2. It has complete control over any Inventory

when creating a GUI library, cancelling the click event appropriately is very important.

Failing to do so may cause non-GUI Inventory to be not responsive, or even worse, if it fails to cancel the click event of GUI Inventory, players may pick up items and thus duplicate items!

Because now we track Inventory by its instance, as long as the instance exist in our `inventories` Map, we can simply cancel the event and rest assured. Because until InventoryCloseEvent is called and the instance is removed from the `inventories,` event will be cancelled no matter what. When Inventory dies, SmartInventory also dies with it.

Then you may ask, "what if InventoryCloseEvent is not called"? That's not going to happen in any case. Even when player lost connection before closing an Inventory, InventoryCloseEvent will be called before PlayerQuitEvent is fired. (Refer to the [link](https://www.spigotmc.org/threads/inventorycloseevent-before-quit.46299/))

---

One downside is that in old versions (such as 1.5.2), Inventory instance change throughout the Inventory events (for example, Inventory instance in InventoryOpenEvent and InventoryClickEvent differ), so it no longer can track which Inventory instance is GUI.

At least tested and confirmed working in 1.16.3, yet I think that this is highly likely not an issue if the server is 1.7 and above.

However, more test will be always better. 

My job is done here since I use only latest version (1.16.3 atm), so it's up to you to merge it or not!