### PR TITLE
Do not store player objects directly because of reference integrity

### DIFF
--- a/src/main/java/fr/minuskube/inv/SmartInventory.java
+++ b/src/main/java/fr/minuskube/inv/SmartInventory.java
@@ -45,7 +45,7 @@ public class SmartInventory {
             this.manager.setInventory(player, null);
         });
 
-        InventoryContents contents = new InventoryContents.Impl(this, player);
+        InventoryContents contents = new InventoryContents.Impl(this, player.getUniqueId());
         contents.pagination().page(page);
 
         this.manager.setContents(player, contents);

--- a/src/main/java/fr/minuskube/inv/content/InventoryContents.java
+++ b/src/main/java/fr/minuskube/inv/content/InventoryContents.java
@@ -2,13 +2,14 @@ package fr.minuskube.inv.content;
 
 import fr.minuskube.inv.ClickableItem;
 import fr.minuskube.inv.SmartInventory;
-import org.bukkit.entity.Player;
+import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface InventoryContents {
 
@@ -52,7 +53,7 @@ public interface InventoryContents {
     class Impl implements InventoryContents {
 
         private SmartInventory inv;
-        private Player player;
+        private UUID player;
 
         private ClickableItem[][] contents;
 
@@ -60,7 +61,7 @@ public interface InventoryContents {
         private Map<String, SlotIterator> iterators = new HashMap<>();
         private Map<String, Object> properties = new HashMap<>();
 
-        public Impl(SmartInventory inv, Player player) {
+        public Impl(SmartInventory inv, UUID player) {
             this.inv = inv;
             this.player = player;
             this.contents = new ClickableItem[inv.getRows()][inv.getColumns()];
@@ -237,7 +238,7 @@ public interface InventoryContents {
             if(!inv.getManager().getOpenedPlayers(inv).contains(player))
                 return;
 
-            Inventory topInventory = player.getOpenInventory().getTopInventory();
+            Inventory topInventory = Bukkit.getPlayer(player).getOpenInventory().getTopInventory();
             topInventory.setItem(inv.getColumns() * row + column, item);
         }
 


### PR DESCRIPTION
The Bukkit / Spigot API makes NO guarantees regarding the integrity of references to Entities (such as Player). Thus, it is advised to only ever store the UUIDs of players and convert them into real players using Bukkit.getPlayer. There are virtually no performance penalties involved because Bukkit.getPlayer internally uses a HashMap to store map UUIDs to Player objects.