### PR TITLE
Update one item in the inventory

### DIFF
--- a/src/main/java/fr/minuskube/inv/ClickableItem.java
+++ b/src/main/java/fr/minuskube/inv/ClickableItem.java
@@ -23,6 +23,16 @@ public class ClickableItem {
         return new ClickableItem(item, consumer);
     }
 
+    /**
+     * Updates the {@code ItemStack} of a {@code ClickableItem} without changing its listener.
+     * @param clickableItem the old {@code ClickableItem}
+     * @param itemStack the new {@code ItemStack}
+     * @return a new {@code ClickableItem} with its related {@code ItemStack} updated
+     */
+    public static ClickableItem updateItem(ClickableItem clickableItem, ItemStack itemStack) {
+        return new ClickableItem(itemStack, clickableItem.consumer);
+    }
+
     public void run(InventoryClickEvent e) { consumer.accept(e); }
 
     public ItemStack getItem() { return item; }

--- a/src/main/java/fr/minuskube/inv/InventoryManager.java
+++ b/src/main/java/fr/minuskube/inv/InventoryManager.java
@@ -80,12 +80,12 @@ public class InventoryManager {
         this.openers.addAll(Arrays.asList(openers));
     }
 
-    public List<Player> getOpenedPlayers(SmartInventory inv) {
-        List<Player> list = new ArrayList<>();
+    public List<UUID> getOpenedPlayers(SmartInventory inv) {
+        List<UUID> list = new ArrayList<>();
 
         this.inventories.forEach((player, playerInv) -> {
             if (inv.equals(playerInv))
-                list.add(Bukkit.getPlayer(player));
+                list.add(player);
         });
 
         return list;

--- a/src/main/java/fr/minuskube/inv/content/InventoryContents.java
+++ b/src/main/java/fr/minuskube/inv/content/InventoryContents.java
@@ -36,13 +36,14 @@ public interface InventoryContents {
 
     InventoryContents add(ClickableItem item);
 
+    InventoryContents update(SlotPos slotPos, ItemStack itemStack);
+
     InventoryContents fill(ClickableItem item);
     InventoryContents fillRow(int row, ClickableItem item);
     InventoryContents fillColumn(int column, ClickableItem item);
     InventoryContents fillBorders(ClickableItem item);
 
-    InventoryContents fillRect(int fromRow, int fromColumn,
-                               int toRow, int toColumn, ClickableItem item);
+    InventoryContents fillRect(int fromRow, int fromColumn, int toRow, int toColumn, ClickableItem item);
     InventoryContents fillRect(SlotPos fromPos, SlotPos toPos, ClickableItem item);
 
     <T> T property(String name);
@@ -160,6 +161,23 @@ public interface InventoryContents {
                 }
             }
 
+            return this;
+        }
+
+        /**
+         * Updates an item in this inventory without reloading the entire GUI.
+         * @param slotPos the position of the item to update
+         * @param itemStack the new {@code ItemStack} that will replace the old one
+         * @return this {@code InventoryContents} instance
+         */
+        @Override
+        public InventoryContents update(SlotPos slotPos, ItemStack itemStack) {
+            Optional<ClickableItem> optional = get(slotPos);
+            if (!optional.isPresent())
+                return this;
+
+            ClickableItem newClickableItem = ClickableItem.updateItem(optional.get(), itemStack);
+            set(slotPos, newClickableItem);
             return this;
         }
 

--- a/src/main/java/fr/minuskube/inv/content/InventoryContents.java
+++ b/src/main/java/fr/minuskube/inv/content/InventoryContents.java
@@ -36,6 +36,12 @@ public interface InventoryContents {
 
     InventoryContents add(ClickableItem item);
 
+    /**
+     * Updates an item in this inventory without reloading the entire GUI.
+     * @param slotPos the position of the item to update
+     * @param itemStack the new {@code ItemStack} that will replace the old one
+     * @return this {@code InventoryContents} instance
+     */
     InventoryContents update(SlotPos slotPos, ItemStack itemStack);
 
     InventoryContents fill(ClickableItem item);
@@ -164,12 +170,6 @@ public interface InventoryContents {
             return this;
         }
 
-        /**
-         * Updates an item in this inventory without reloading the entire GUI.
-         * @param slotPos the position of the item to update
-         * @param itemStack the new {@code ItemStack} that will replace the old one
-         * @return this {@code InventoryContents} instance
-         */
         @Override
         public InventoryContents update(SlotPos slotPos, ItemStack itemStack) {
             Optional<ClickableItem> optional = get(slotPos);


### PR DESCRIPTION
Added the feature to update a single item in the inventory, without changing the item's listener.
The GUI is not reloaded when calling `InventoryContents#update`.