### PR TITLE
Fix subsequent calls to InventoryContents#set() not working

### DIFF
--- a/src/main/java/fr/minuskube/inv/content/InventoryContents.java
+++ b/src/main/java/fr/minuskube/inv/content/InventoryContents.java
@@ -3,6 +3,7 @@ package fr.minuskube.inv.content;
 import fr.minuskube.inv.ClickableItem;
 import fr.minuskube.inv.SmartInventory;
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
@@ -235,10 +236,11 @@ public interface InventoryContents {
         }
 
         private void update(int row, int column, ItemStack item) {
-            if(!inv.getManager().getOpenedPlayers(inv).contains(player))
+            Player currentPlayer = Bukkit.getPlayer(player);
+            if(!inv.getManager().getOpenedPlayers(inv).contains(currentPlayer))
                 return;
 
-            Inventory topInventory = Bukkit.getPlayer(player).getOpenInventory().getTopInventory();
+            Inventory topInventory = currentPlayer.getOpenInventory().getTopInventory();
             topInventory.setItem(inv.getColumns() * row + column, item);
         }
 


### PR DESCRIPTION
`smartInventory.getManager().getOpenedPlayers(smartInventory)` returns a `List<Player>`, against which `InventoryContents#update()` calls `contains()` with a `UUID`, causing any subsequent calls to `InventoryContents#set()` to not update in the inventory.

Caused by 7382db3da7988a4d2fa790fbf59f4f9332457620

Relevant bug: #179 

This PR aims to resolve this issue.